### PR TITLE
Correct PRG instantiation from object to val in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,14 +124,14 @@ To represent the DSL summing them all, Freek provides you with the following not
 
 ```scala
 type PRG = Log :|: KVS :|: File :|: FXNil
-object PRG = Program[PRG]
+val PRG = Program[PRG]
 ```
 
 Please note:
 
 - `FXNil` is required at the end of the coproduct
 - Some will complain on the ugly symbol `:|:` but in Scala, there is no other elegant way to combine types...
-- `object PRG = Program[PRG]` is the way to instantiate an object that represents your `PRG` type. It might seem artificial and actually it is completely: it is just required to convince scalac that it can infer the right coproduct in output and will be used later.
+- `val PRG = Program[PRG]` is the way to instantiate an object that represents your `PRG` type. It might seem artificial and actually it is completely: it is just required to convince scalac that it can infer the right coproduct in output and will be used later.
 
 <br/>
 <br/>


### PR DESCRIPTION
See issue #2

I don't thinl you can "object PRG = Program[PRG]" in scala. Perhaps it was an "object PRG extends Program[PRG]" in the early days ?

All in all, change the readme so that a noob like me just has to copy&paste without to much thinking when he first try Freek for real :) 
